### PR TITLE
Update UI to use resource/group terminology v. service/organization

### DIFF
--- a/hsdirectory/src/app/layout.tsx
+++ b/hsdirectory/src/app/layout.tsx
@@ -16,7 +16,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: "HSDirectory - Find Community Services",
+    default: "HSDirectory - Find Community Resources",
     template: "%s | HSDirectory",
   },
   description: "Search and discover community services and resources in your area. Powered by Open Referral HSDS.",

--- a/hsdirectory/src/app/not-found.tsx
+++ b/hsdirectory/src/app/not-found.tsx
@@ -44,7 +44,7 @@ export default function NotFound() {
               border border-[var(--card-border)] text-[var(--foreground)] opacity-70
               hover:bg-[var(--section-alt)] hover:opacity-100 transition-all"
                     >
-                        Browse Services
+                        Browse Resources
                     </Link>
                 </div>
             </div>

--- a/hsdirectory/src/app/organizations/OrgSearch.tsx
+++ b/hsdirectory/src/app/organizations/OrgSearch.tsx
@@ -8,7 +8,7 @@ interface OrgSearchProps {
 }
 
 /**
- * Client-side search input for the organizations page.
+ * Client-side search input for the groups page.
  * Submitting navigates to /organizations?q=... which triggers
  * a server-side re-fetch with the search parameter.
  */
@@ -41,7 +41,7 @@ export function OrgSearch({ initialQuery = '' }: OrgSearchProps) {
                     type="text"
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
-                    placeholder="Search organizations by name..."
+                    placeholder="Search groups by name..."
                     className="w-full pl-10 pr-24 py-3 rounded-xl border border-[var(--card-border)] bg-[var(--card-bg)] text-[var(--foreground)] shadow-sm focus:border-[var(--primary)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]/20"
                 />
                 <div className="absolute right-2 flex items-center gap-1">

--- a/hsdirectory/src/app/organizations/[id]/page.tsx
+++ b/hsdirectory/src/app/organizations/[id]/page.tsx
@@ -10,7 +10,7 @@ interface OrganizationDetailPageProps {
 }
 
 /**
- * Generate dynamic metadata for organization detail page.
+ * Generate dynamic metadata for group detail page.
  */
 export async function generateMetadata({ params }: OrganizationDetailPageProps): Promise<Metadata> {
     const { id } = await params;
@@ -18,18 +18,18 @@ export async function generateMetadata({ params }: OrganizationDetailPageProps):
         const organization = await getOrganization(id);
         return {
             title: organization.name,
-            description: organization.description || `Services provided by ${organization.name}`,
+            description: organization.description || `Resources provided by ${organization.name}`,
         };
     } catch {
         return {
-            title: "Organization Not Found",
+            title: "Group Not Found",
         };
     }
 }
 
 /**
- * Organization detail page showing organization info and their services.
- * Two-column layout: Left (info + services), Right (multi-pin map)
+ * Group detail page showing group info and its resources.
+ * Two-column layout: Left (info + resources), Right (multi-pin map)
  */
 export default async function OrganizationDetailPage({ params }: OrganizationDetailPageProps) {
     const { id } = await params;
@@ -46,7 +46,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
         notFound();
     }
 
-    // Collect all service locations by matching related service IDs
+    // Collect all resource locations by matching related service IDs
     // against the geocoded map data (which has lat/lng for each service).
     interface MapPin {
         id: string;
@@ -90,7 +90,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
                     <li>/</li>
                     <li>
                         <Link href="/organizations" className="hover:text-[var(--foreground)]">
-                            Organizations
+                            Groups
                         </Link>
                     </li>
                     <li>/</li>
@@ -102,9 +102,9 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
 
             {/* Two-Column Layout */}
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                {/* Left Column - Organization Info and Services */}
+                {/* Left Column - Group Info and Resources */}
                 <div className="lg:col-span-2 space-y-8">
-                    {/* Organization Header */}
+                    {/* Group Header */}
                     <div className="rounded-xl border border-[var(--card-border)] bg-[var(--card-bg)] p-6">
                         {/* Name */}
                         <h1 className="font-display text-3xl font-bold text-[var(--foreground)] mb-4">
@@ -149,10 +149,10 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
                         </div>
                     </div>
 
-                    {/* Services Section */}
+                    {/* Resources Section */}
                     <section>
                         <h2 className="font-display text-2xl font-bold text-[var(--foreground)] mb-6">
-                            Services ({relatedServices.length})
+                            Resources ({relatedServices.length})
                         </h2>
 
                         {relatedServices.length > 0 ? (
@@ -164,7 +164,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
                         ) : (
                             <div className="text-center py-12 bg-[var(--section-alt)] rounded-xl">
                                 <p className="text-[var(--muted)]">
-                                    No services listed for this organization yet.
+                                    No resources listed for this group yet.
                                 </p>
                             </div>
                         )}
@@ -178,7 +178,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
                             <div className="rounded-xl border border-[var(--card-border)] bg-[var(--card-bg)] overflow-hidden">
                                 <div className="p-4 border-b border-[var(--card-border)]">
                                     <h3 className="font-semibold text-[var(--foreground)]">
-                                        Service Locations ({mapLocations.length})
+                                        Resource Locations ({mapLocations.length})
                                     </h3>
                                 </div>
                                 <OrgLocationsMap locations={mapLocations} />
@@ -207,7 +207,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
                             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                             </svg>
-                            Back to Organizations
+                            Back to Groups
                         </Link>
                     </div>
                 </div>

--- a/hsdirectory/src/app/organizations/page.tsx
+++ b/hsdirectory/src/app/organizations/page.tsx
@@ -5,8 +5,8 @@ import { Pagination } from "@/components/ui/Pagination";
 import { OrgSearch } from "./OrgSearch";
 
 export const metadata: Metadata = {
-    title: "Organizations",
-    description: "Browse organizations providing community services and resources.",
+    title: "Groups",
+    description: "Browse groups providing community resources.",
 };
 
 interface OrganizationsPageProps {
@@ -14,7 +14,7 @@ interface OrganizationsPageProps {
 }
 
 /**
- * Organizations listing page with search and pagination.
+ * Groups listing page with search and pagination.
  * The `q` param drives server-side text search against the API.
  */
 export default async function OrganizationsPage({ searchParams }: OrganizationsPageProps) {
@@ -45,10 +45,10 @@ export default async function OrganizationsPage({ searchParams }: OrganizationsP
             {/* Page Header */}
             <div className="mb-8">
                 <h1 className="font-display text-3xl font-bold text-[var(--foreground)] mb-4">
-                    Organizations
+                    Groups
                 </h1>
                 <p className="text-[var(--muted)]">
-                    {totalItems.toLocaleString()} organizations providing community services
+                    {totalItems.toLocaleString()} groups providing community resources
                 </p>
             </div>
 
@@ -64,7 +64,7 @@ export default async function OrganizationsPage({ searchParams }: OrganizationsP
                 </div>
             )}
 
-            {/* Organizations Grid */}
+            {/* Groups Grid */}
             {organizations.length > 0 ? (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
                     {organizations.map((org) => (
@@ -80,10 +80,10 @@ export default async function OrganizationsPage({ searchParams }: OrganizationsP
                         </svg>
                     </div>
                     <h3 className="text-lg font-medium text-[var(--foreground)] mb-2">
-                        {query ? `No results for "${query}"` : "No organizations found"}
+                        {query ? `No results for "${query}"` : "No groups found"}
                     </h3>
                     <p className="text-[var(--muted)]">
-                        {query ? "Try a different search term." : "No organizations are currently available."}
+                        {query ? "Try a different search term." : "No groups are currently available."}
                     </p>
                 </div>
             ) : null}

--- a/hsdirectory/src/app/page.tsx
+++ b/hsdirectory/src/app/page.tsx
@@ -52,7 +52,7 @@ const EXCLUDED_TERMS = new Set(["-Not Listed", "Not Listed"]);
  * Homepage with warm community-oriented design inspired by mutualaid.nyc.
  */
 export default async function Home() {
-  let stats = { services: 0, organizations: 0 };
+  let stats = { resources: 0, groups: 0 };
   let categories: string[] = [];
 
   try {
@@ -62,8 +62,8 @@ export default async function Home() {
       getMapServices(),
     ]);
     stats = {
-      services: servicesRes.total_items || 0,
-      organizations: orgsRes.total_items || 0,
+      resources: servicesRes.total_items || 0,
+      groups: orgsRes.total_items || 0,
     };
     categories = (mapData.needCategories || []).filter(
       (c: string) => !EXCLUDED_TERMS.has(c)
@@ -85,10 +85,10 @@ export default async function Home() {
               We help build and strengthen local mutual aid networks.
             </p>
             <p className="text-lg text-[var(--muted)] mb-10">
-              Search our directory of {stats.services.toLocaleString()} services
-              from {stats.organizations.toLocaleString()} organizations
+              Search our directory of {stats.resources.toLocaleString()} resources
+              from {stats.groups.toLocaleString()} groups
             </p>
-            <SearchBar placeholder="What service are you looking for?" />
+            <SearchBar placeholder="What resource are you looking for?" />
           </div>
         </div>
       </section>
@@ -139,19 +139,19 @@ export default async function Home() {
         </div>
       </section>
 
-      {/* Service Categories — warm earthy colored cards */}
+      {/* Resource Categories — warm earthy colored cards */}
       {categories.length > 0 && (
         <section className="py-16 px-4">
           <div className="container mx-auto">
             <div className="flex items-center justify-between mb-8">
               <h2 className="font-display text-2xl font-bold text-[var(--foreground)]">
-                All Resources
+                Browse By Category
               </h2>
               <Link
                 href="/services"
                 className="text-[var(--primary)] hover:text-[var(--primary-hover)] font-medium transition-colors"
               >
-                View all services →
+                View all resources →
               </Link>
             </div>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">

--- a/hsdirectory/src/app/services/MapPageClient.tsx
+++ b/hsdirectory/src/app/services/MapPageClient.tsx
@@ -178,7 +178,7 @@ export default function MapPageClient({
         syncUrl('', '', '', '');
     };
 
-    // Filter and rank services by relevance.
+    // Filter and rank resources by relevance.
     // Each search token earns points based on which field it matches:
     //   Name match = 4pts, Tag match = 3pts, Address = 2pts, Description = 1pt.
     // Results are sorted by total score (highest first).
@@ -277,7 +277,7 @@ export default function MapPageClient({
                                 setSearchQuery(e.target.value);
                                 syncUrl(e.target.value, selectedNeed, selectedCommunity, selectedBorough);
                             }}
-                            placeholder="Search services..."
+                            placeholder="Search resources..."
                             className="w-full rounded-lg border border-[var(--card-border)] bg-[var(--card-bg)] px-3 py-2 text-sm text-[var(--foreground)] focus:ring-2 focus:ring-[var(--primary)] focus:border-transparent"
                         />
                     </form>
@@ -378,20 +378,20 @@ export default function MapPageClient({
 
                 {/* Results count */}
                 <div className="mt-4 text-sm text-[var(--muted)]">
-                    {filteredServices.length} services found
+                    {filteredServices.length} resources found
                 </div>
             </div>
 
-            {/* Middle Column: Service Cards */}
+            {/* Middle Column: Resource Cards */}
             <div className="w-[32rem] flex-shrink-0 border-r border-[var(--card-border)] overflow-y-auto scrollbar-thin">
                 <div className="p-4 space-y-4">
                     {filteredServices.length === 0 ? (
                         <div className="text-center py-8 text-[var(--muted)]">
-                            No services match your filters
+                            No resources match your filters
                         </div>
                     ) : (
                         filteredServices.map(service => (
-                            <ServiceCard
+                            <ResourceCard
                                 key={service.id}
                                 service={service}
                                 userLocation={userLocation}
@@ -413,9 +413,9 @@ export default function MapPageClient({
 }
 
 /**
- * Service card component
+ * Resource card component
  */
-function ServiceCard({ service, userLocation, onHover }: {
+function ResourceCard({ service, userLocation, onHover }: {
     service: Service;
     userLocation: { lat: number; lng: number } | null;
     onHover: (id: string | null) => void;
@@ -482,7 +482,7 @@ function ServiceCard({ service, userLocation, onHover }: {
                 </p>
             )}
 
-            {/* Service Category tags */}
+            {/* Need Category tags */}
             {service.needFocus && service.needFocus.length > 0 && (
                 <div className="flex flex-wrap gap-1.5 mb-2">
                     {service.needFocus.map((need, i) => (

--- a/hsdirectory/src/app/services/[id]/page.tsx
+++ b/hsdirectory/src/app/services/[id]/page.tsx
@@ -114,7 +114,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                     <li>/</li>
                     <li>
                         <Link href="/services" className="hover:text-[var(--foreground)]">
-                            Services
+                            Resources
                         </Link>
                     </li>
                     <li>/</li>
@@ -162,11 +162,11 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                             </p>
                         )}
 
-                        {/* Service Categories */}
+                        {/* Need Categories */}
                         {(service.need_focus?.length ?? 0) > 0 && (
                             <div className="mb-4">
                                 <h3 className="text-sm font-semibold text-[var(--foreground)] opacity-70 mb-2 uppercase tracking-wide">
-                                    Service Categories
+                                    Need Categories
                                 </h3>
                                 <div className="flex flex-wrap gap-2">
                                     {service.need_focus!.map((need: string, index: number) => (
@@ -207,7 +207,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                     {service.description && (
                         <section>
                             <h2 className="text-xl font-semibold text-[var(--foreground)] mb-4">
-                                About This Service
+                                Description
                             </h2>
                             <div className="prose max-w-none">
                                 <p className="text-[var(--muted)] whitespace-pre-wrap">

--- a/hsdirectory/src/components/organizations/OrganizationCard.tsx
+++ b/hsdirectory/src/components/organizations/OrganizationCard.tsx
@@ -6,7 +6,7 @@ interface OrganizationCardProps {
 }
 
 /**
- * Card component for displaying organization summary in lists.
+ * Card component for displaying group summary in lists.
  */
 export function OrganizationCard({ organization }: OrganizationCardProps) {
     return (
@@ -31,7 +31,7 @@ export function OrganizationCard({ organization }: OrganizationCardProps) {
                 </div>
 
                 <div className="flex-1 min-w-0">
-                    {/* Organization Name */}
+                    {/* Group Name */}
                     <h3 className="font-semibold text-lg text-[var(--foreground)] group-hover:text-[var(--primary)] truncate">
                         {organization.name}
                     </h3>
@@ -43,7 +43,7 @@ export function OrganizationCard({ organization }: OrganizationCardProps) {
                         </p>
                     )}
 
-                    {/* Service Count and Links */}
+                    {/* Resource Count and Links */}
                     <div className="mt-3 flex flex-wrap gap-3 text-sm">
                         {organization.service_count !== undefined && organization.service_count > 0 && (
                             <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-[var(--tag-olive-bg)] text-[var(--tag-olive-text)]">
@@ -51,7 +51,7 @@ export function OrganizationCard({ organization }: OrganizationCardProps) {
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                                         d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                                 </svg>
-                                {organization.service_count} {organization.service_count === 1 ? 'Service' : 'Services'}
+                                {organization.service_count} {organization.service_count === 1 ? 'Resource' : 'Resources'}
                             </span>
                         )}
                         {organization.url && (

--- a/hsdirectory/src/components/ui/Footer.tsx
+++ b/hsdirectory/src/components/ui/Footer.tsx
@@ -11,17 +11,17 @@ export function Footer() {
                     {/* Branding */}
                     <div className="flex items-center gap-2">
                         <span className="font-display text-lg font-bold text-[var(--nav-text)]">
-                            Mutual Aid <span className="text-[var(--primary)]">NYC</span>
+                            Mutual Aid NYC
                         </span>
                     </div>
 
                     {/* Links */}
                     <nav className="flex flex-wrap gap-6 text-sm text-[var(--nav-text)] opacity-70">
                         <Link href="/services" className="hover:opacity-100 transition-opacity">
-                            Services
+                            Resources
                         </Link>
                         <Link href="/organizations" className="hover:opacity-100 transition-opacity">
-                            Organizations
+                            Groups
                         </Link>
                     </nav>
 

--- a/hsdirectory/src/components/ui/Header.tsx
+++ b/hsdirectory/src/components/ui/Header.tsx
@@ -18,20 +18,20 @@ export function Header({ showSearch = true }: HeaderProps) {
                 <Link href="/" className="flex items-center gap-3">
                     <Image
                         src="/logo.png"
-                        alt="Mutual Aid NYC"
-                        width={40}
-                        height={40}
+                        alt="Mutual Aid NYC logo"
+                        width={60}
+                        height={60}
                         className="rounded-full"
                     />
-                    <span className="font-display text-xl font-bold text-[var(--nav-text)] tracking-tight">
-                        Mutual Aid <span className="text-[var(--highlight)]">NYC</span>
+                    <span className="font-display text-xl text-[var(--nav-text)] tracking-tight">
+                        Community Resources Library
                     </span>
                 </Link>
 
                 {/* Search Bar (compact) */}
                 {showSearch && (
                     <div className="hidden md:block flex-1 max-w-md mx-8">
-                        <SearchBar size="sm" placeholder="Search services..." />
+                        <SearchBar size="sm" placeholder="Search resources..." />
                     </div>
                 )}
 


### PR DESCRIPTION
Fix issue #1 

Align site terminology to match Mutual Aid NYC "Community Resources Library" approach to encompass both social services and mutual aid. Also updated site title in header to "Community Resources Library."

To test in UI:
1. Follow README to run NextJS app locally with data loaded
2. Check pages to ensure expected language is aligned across app. "Service" replaced by "Resource" and "Organization" replaced by "Group"