### PR TITLE
Switch to new service_at_locations endpoint implementation

### DIFF
--- a/application_layer/application_layer.py
+++ b/application_layer/application_layer.py
@@ -15,10 +15,12 @@ from models.hsds import (
     Address,
     Contact,
     Location,
+    Page,
     Phone,
     Schedule,
     ServiceAtLocation,
 )
+from typing import List
 
 def list_service_at_locations(
     service_at_locations_table: DataEntity[ServiceAtLocationResponse],
@@ -33,7 +35,7 @@ def list_service_at_locations(
     page: int = 1,
     per_page: int = 20,
     full: bool = False,
-) -> list[ServiceAtLocation]:
+) -> Page:
     services_at_locations = service_at_locations_table.list()
     services = services_table.list(
         filters=[
@@ -61,7 +63,7 @@ def list_service_at_locations(
         )
         results.append(res)
 
-    return results
+    return _paginate_results(results=results, page=page, per_page=per_page)
 
 
 def get_service_at_locations(
@@ -182,4 +184,23 @@ def _create_service_at_location_result(
         contacts=contacts,
         phones=phones,
         schedules=schedules,
+    )
+
+def _paginate_results(results: list[ServiceAtLocation], page: int, per_page: int) -> Page:
+    total = len(results)
+    total_pages = max(1, (total + per_page - 1) // per_page)
+    
+    start = (page - 1) * per_page
+    end = start + per_page
+    page_items = results[start:end]
+    
+    return Page(
+        total_items=total,
+        total_pages=total_pages,
+        page_number=page,
+        size=len(page_items),
+        first_page=(page == 1),
+        last_page=(page >= total_pages),
+        empty=(len(page_items) == 0),
+        contents=page_items,
     )

--- a/application_layer/application_layer.py
+++ b/application_layer/application_layer.py
@@ -1,3 +1,4 @@
+
 from config import Settings
 from data_layer.data import DataEntity, Filter
 from models.airtable import (
@@ -20,7 +21,6 @@ from models.hsds import (
     Schedule,
     ServiceAtLocation,
 )
-from typing import List
 
 def list_service_at_locations(
     service_at_locations_table: DataEntity[ServiceAtLocationResponse],
@@ -189,11 +189,11 @@ def _create_service_at_location_result(
 def _paginate_results(results: list[ServiceAtLocation], page: int, per_page: int) -> Page:
     total = len(results)
     total_pages = max(1, (total + per_page - 1) // per_page)
-    
+
     start = (page - 1) * per_page
     end = start + per_page
     page_items = results[start:end]
-    
+
     return Page(
         total_items=total,
         total_pages=total_pages,

--- a/data_layer/airtable.py
+++ b/data_layer/airtable.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import builtins
 from time import sleep
-from typing import Any, TypeVar, Optional, List
+from typing import Any, TypeVar
 
 import httpx
 

--- a/data_layer/airtable.py
+++ b/data_layer/airtable.py
@@ -55,10 +55,13 @@ class AirtableData(DataEntity[T]):
         self,
         endpoint: str,
         params: dict[str, Any],
+        offset: int = 0,
         limit: int | None = None,
     ) -> list[dict[str, Any]]:
         attempts = 0
         all_records = []
+
+        params['offset'] = offset
         with httpx.Client(timeout=30.0) as client:
             while attempts < BASE_RETRY_LIMIT:
                 url = f"{BASE_URL}/{self.base_id}/{endpoint}"
@@ -76,8 +79,8 @@ class AirtableData(DataEntity[T]):
                 records = data.get("records", [])
                 all_records.extend(records)
 
-                offset = data.get("offset")
-                if not offset:
+                params['offset'] = data.get("offset")
+                if not params['offset']:
                     break
 
                 if limit and len(all_records) > limit:
@@ -92,6 +95,7 @@ class AirtableData(DataEntity[T]):
     def list(
         self,
         filters: list[Filter] | None = None,
+        offset: int = 0,
         limit: int | None = None,
     ) -> list[T]:
         table_id = TABLE_IDS.get(self.table.name)
@@ -107,6 +111,7 @@ class AirtableData(DataEntity[T]):
         raw_records = self._make_request(
             endpoint=table_id,
             params=params,
+            offset=offset,
             limit=limit,
         )
         return [

--- a/data_layer/data.py
+++ b/data_layer/data.py
@@ -27,7 +27,8 @@ class DataEntity(ABC, Generic[T]):
     def list(
         self,
         filters: list[Filter] | None = None,
-        max: int | None = None,
+        offset: int = 0,
+        limit: int | None = None,
     ) -> list[T]:
         ...
 
@@ -53,16 +54,17 @@ class TestData(DataEntity[T]):
     def list(
         self,
         filters: list[Filter] | None = None,
-        max: int | None = None,
+        offset: int = 0,
+        limit: int | None = None,
     ) -> list[T]:
         return [
             self.data[index]
-            for index in self.data
+            for index in (self.data)
             if not filters or any(
                 getattr(self.data[index], filter.key) == filter.value
                 for filter in filters
             )
-        ]
+        ][offset : (offset + limit) if limit else None]
 
     def get(
         self,

--- a/data_layer/data.py
+++ b/data_layer/data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import builtins
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, Optional, List
+from typing import TypeVar
 
 from pydantic import BaseModel
 
@@ -18,7 +18,7 @@ class Filter(BaseModel):
     key: str
     value: str
 
-class DataEntity(ABC, Generic[T]):
+class DataEntity[T](ABC):
     def __init__(self, model_class: type[T]):
         self.model_class = model_class
         super().__init__()

--- a/data_layer/data.py
+++ b/data_layer/data.py
@@ -59,7 +59,7 @@ class TestData(DataEntity[T]):
     ) -> list[T]:
         return [
             self.data[index]
-            for index in (self.data)
+            for index in self.data
             if not filters or any(
                 getattr(self.data[index], filter.key) == filter.value
                 for filter in filters

--- a/main.py
+++ b/main.py
@@ -14,7 +14,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from config import get_settings
 from db.database import init_db
 from airtable.sync import get_sync
-from routes import root, services, organizations, taxonomies, service_at_locations, locations, map
+from routes import root, services, organizations, taxonomies, locations, map
+from routes_updated import service_at_locations
 
 # Configure logging
 logging.basicConfig(

--- a/routes/service_at_locations.py
+++ b/routes/service_at_locations.py
@@ -4,18 +4,12 @@ Service at Locations API endpoints.
 OPTIONAL endpoints per HSDS specification.
 """
 from typing import Optional
-from fastapi import APIRouter, HTTPException, Query
-from models.hsds import ServiceAtLocation, Page
+from fastapi import HTTPException, Query
+from models.hsds import ServiceAtLocation
 from airtable.client import get_airtable_client
 from transform.mapper import HSDSMapper
 from config import get_settings
-from data_layer import dependency
-from application_layer import application_layer
 
-router = APIRouter(prefix="/service_at_locations", tags=["service_at_locations"])
-
-
-@router.get("", response_model=Page)
 async def list_service_at_locations(
     search: Optional[str] = Query(None, description="Full text search"),
     page: int = Query(1, ge=1, description="Page number"),
@@ -68,44 +62,6 @@ async def list_service_at_locations(
     return mapper.paginate(results, page, per_page)
 
 
-async def list_service_at_locations_updated(
-    search: Optional[str] = None,
-    page: int = 1,
-    per_page: int = 20,
-    taxonomy_term_id: Optional[str] = None,
-    taxonomy_id: Optional[str] = None,
-    organization_id: Optional[str] = None,
-    modified_after: Optional[str] = None,
-    full: bool = False,
-    postcode: Optional[str] = None,
-    proximity: Optional[int] = None,
-) -> Page:
-    service_at_locations_table = dependency.get_service_at_locations_table()
-    services_table = dependency.get_service_table()
-    location_table = dependency.get_locations_table()
-    addresses_table = dependency.get_addresses_table()
-    contacts_table = dependency.get_contacts_table()
-    phones_table = dependency.get_phones_table()
-    schedule_table = dependency.get_schedule_table()
-    accessibilities_table = dependency.get_accessibility_table()
-    settings = get_settings()
-
-    return application_layer.list_service_at_locations(
-        service_at_locations_table=service_at_locations_table,
-        services_table=services_table,
-        locations_table=location_table,
-        addresses_table=addresses_table,
-        accessibilities_table=accessibilities_table,
-        contacts_table=contacts_table,
-        phones_table=phones_table,
-        schedule_table=schedule_table,
-        settings=settings,
-        page=page,
-        per_page=per_page,
-        full=full,
-    )
-
-@router.get("/{sal_id}", response_model=ServiceAtLocation)
 async def get_service_at_location(sal_id: str):
     """
     Get a single service_at_location with all related data.
@@ -127,26 +83,6 @@ async def get_service_at_location(sal_id: str):
     fields = record.get("fields", {})
     
     return await _get_full_service_at_location(record["id"], fields, mapper, client)
-
-async def get_service_at_location_updated(sal_id: str):
-    service_at_location_table = dependency.get_service_at_locations_table()
-    addresses_table = dependency.get_addresses_table()
-    contacts_table = dependency.get_contacts_table()
-    phones_table = dependency.get_phones_table()
-    schedule_table = dependency.get_schedule_table()
-    locations_table = dependency.get_locations_table()
-    accessibility_table = dependency.get_accessibility_table()
-
-    return application_layer.get_service_at_locations(
-        sal_id=sal_id,
-        service_at_locations_table=service_at_location_table,
-        addresses_table=addresses_table,
-        contacts_table=contacts_table,
-        phones_table=phones_table,
-        schedule_table=schedule_table,
-        locations_table=locations_table,
-        accessibilities_table=accessibility_table,
-    )
 
 
 async def _get_full_service_at_location(

--- a/routes_updated/service_at_locations.py
+++ b/routes_updated/service_at_locations.py
@@ -30,7 +30,7 @@ async def get_service_at_location(sal_id: str):
         accessibilities_table=accessibility_table,
     )
 
-@router.get("/list", response_model=Page)
+@router.get("", response_model=Page)
 async def list_service_at_locations(
     search: Optional[str] = None,
     page: int = 1,

--- a/routes_updated/service_at_locations.py
+++ b/routes_updated/service_at_locations.py
@@ -9,7 +9,7 @@ from models.hsds import Page, ServiceAtLocation
 router = APIRouter(prefix="/service_at_locations", tags=["service_at_locations"])
 
 
-@router.get("", response_model=ServiceAtLocation)
+@router.get("{/sal_id}", response_model=ServiceAtLocation)
 async def get_service_at_location(sal_id: str):
     service_at_location_table = dependency.get_service_at_locations_table()
     addresses_table = dependency.get_addresses_table()

--- a/routes_updated/service_at_locations.py
+++ b/routes_updated/service_at_locations.py
@@ -1,0 +1,69 @@
+from fastapi import APIRouter
+from typing import Optional
+
+from application_layer import application_layer
+from config import get_settings
+from data_layer import dependency
+from models.hsds import Page, ServiceAtLocation
+
+router = APIRouter(prefix="/service_at_locations", tags=["service_at_locations"])
+
+
+@router.get("", response_model=ServiceAtLocation)
+async def get_service_at_location(sal_id: str):
+    service_at_location_table = dependency.get_service_at_locations_table()
+    addresses_table = dependency.get_addresses_table()
+    contacts_table = dependency.get_contacts_table()
+    phones_table = dependency.get_phones_table()
+    schedule_table = dependency.get_schedule_table()
+    locations_table = dependency.get_locations_table()
+    accessibility_table = dependency.get_accessibility_table()
+
+    return application_layer.get_service_at_locations(
+        sal_id=sal_id,
+        service_at_locations_table=service_at_location_table,
+        addresses_table=addresses_table,
+        contacts_table=contacts_table,
+        phones_table=phones_table,
+        schedule_table=schedule_table,
+        locations_table=locations_table,
+        accessibilities_table=accessibility_table,
+    )
+
+@router.get("/list", response_model=Page)
+async def list_service_at_locations(
+    search: Optional[str] = None,
+    page: int = 1,
+    per_page: int = 20,
+    taxonomy_term_id: Optional[str] = None,
+    taxonomy_id: Optional[str] = None,
+    organization_id: Optional[str] = None,
+    modified_after: Optional[str] = None,
+    full: bool = False,
+    postcode: Optional[str] = None,
+    proximity: Optional[int] = None,
+) -> Page:
+    service_at_locations_table = dependency.get_service_at_locations_table()
+    services_table = dependency.get_service_table()
+    location_table = dependency.get_locations_table()
+    addresses_table = dependency.get_addresses_table()
+    contacts_table = dependency.get_contacts_table()
+    phones_table = dependency.get_phones_table()
+    schedule_table = dependency.get_schedule_table()
+    accessibilities_table = dependency.get_accessibility_table()
+    settings = get_settings()
+
+    return application_layer.list_service_at_locations(
+        service_at_locations_table=service_at_locations_table,
+        services_table=services_table,
+        locations_table=location_table,
+        addresses_table=addresses_table,
+        accessibilities_table=accessibilities_table,
+        contacts_table=contacts_table,
+        phones_table=phones_table,
+        schedule_table=schedule_table,
+        settings=settings,
+        page=page,
+        per_page=per_page,
+        full=full,
+    )

--- a/tests/smoke/test_service_at_locations.py
+++ b/tests/smoke/test_service_at_locations.py
@@ -1,6 +1,6 @@
 import pytest
 
-from models.hsds import ServiceAtLocation
+from models.hsds import Page, ServiceAtLocation
 from routes_updated import service_at_locations
 
 @pytest.fixture
@@ -46,7 +46,7 @@ async def test_service_at_locations_list_service_at_locations():
             full=True,
         )
 
-    assert isinstance(all_services_at_locations, list)
+    assert isinstance(all_services_at_locations, Page)
     assert all(
-        isinstance(item, ServiceAtLocation) for item in all_services_at_locations
+        isinstance(item, ServiceAtLocation) for item in all_services_at_locations.contents
     )

--- a/tests/smoke/test_service_at_locations.py
+++ b/tests/smoke/test_service_at_locations.py
@@ -1,7 +1,7 @@
 import pytest
 
 from models.hsds import ServiceAtLocation
-from routes import service_at_locations
+from routes_updated import service_at_locations
 
 @pytest.fixture
 def test_id() -> str:
@@ -10,7 +10,7 @@ def test_id() -> str:
 @pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_service_at_locations_get(test_id: str):
-    sal = await service_at_locations.get_service_at_location_updated(
+    sal = await service_at_locations.get_service_at_location(
         sal_id=test_id
     )
 
@@ -19,7 +19,7 @@ async def test_service_at_locations_get(test_id: str):
 @pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_service_at_locations_get_not_found():
-    sal = await service_at_locations.get_service_at_location_updated(
+    sal = await service_at_locations.get_service_at_location(
         sal_id="nonexistent_id"
     )
 
@@ -28,7 +28,7 @@ async def test_service_at_locations_get_not_found():
 @pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_service_at_locations_get_no_location(test_id: str):
-    sal = await service_at_locations.get_service_at_location_updated(
+    sal = await service_at_locations.get_service_at_location(
         sal_id=test_id
     )
 
@@ -40,7 +40,7 @@ async def test_service_at_locations_get_no_location(test_id: str):
 @pytest.mark.asyncio
 async def test_service_at_locations_list_service_at_locations():
     all_services_at_locations: list[ServiceAtLocation] = \
-        await service_at_locations.list_service_at_locations_updated(
+        await service_at_locations.list_service_at_locations(
             page=1,
             per_page=10,
             full=True,

--- a/tests/unit/application_layer/test_application_layer.py
+++ b/tests/unit/application_layer/test_application_layer.py
@@ -379,7 +379,7 @@ def test_list_service_at_locations_returns_only_published_services(
     expected_service_at_location_with_locations_result: ServiceAtLocation,
     expected_service_at_location_with_no_locations_result: ServiceAtLocation,
 ):
-    service_at_locations_results = application_layer.list_service_at_locations(
+    service_at_locations_page = application_layer.list_service_at_locations(
         service_at_locations_table=test_service_at_location_data,
         services_table=test_services_data,
         locations_table=test_locations_data,
@@ -391,6 +391,7 @@ def test_list_service_at_locations_returns_only_published_services(
         settings=test_settings,
         full=True,
     )
+    service_at_locations_results = service_at_locations_page.contents
 
     assert len(service_at_locations_results) == 1
     assert any(


### PR DESCRIPTION
1. Moved new `service_at_locations` functions to new `routes_updated` directory to give a clear delineation of old/new work
2. Call new service_at_locations function(s) on endpoint invocation