### PR TITLE
Refactor frontend to remove inline styles and better align styles with mutualaid.nyc site

### DIFF
--- a/hsdirectory/README.md
+++ b/hsdirectory/README.md
@@ -1,18 +1,15 @@
 # HSDirectory
 
-A modern, responsive search interface for Human Services Data Specification (HSDS) APIs. Built with Next.js 14, TypeScript, and TailwindCSS.
-
-![HSDirectory](https://via.placeholder.com/800x400/2563eb/ffffff?text=HSDirectory)
+A responsive search interface for Human Services Data Specification (HSDS) APIs. Built with Next.js 14, TypeScript, and TailwindCSS.
 
 ## Features
 
-- 🔍 **Full-text search** - Search across all services
-- 📋 **Service browsing** - Paginated listing with detail views
-- 🏢 **Organizations** - Browse service providers
-- 🗺️ **Interactive map** - MapLibre GL powered location view
-- 📱 **Mobile responsive** - Works on all devices
-- 🌓 **Dark mode** - Automatic dark mode support
-- ⚡ **Fast** - Server-side rendering with Next.js App Router
+- **Full-text search** - Search across all services
+- **Service browsing** - Paginated listing with detail views
+- **Organizations** - Browse service providers
+- **Interactive map** - MapLibre GL powered location view
+- **Mobile responsive** - Works on all devices
+- **Fast** - Server-side rendering with Next.js App Router
 
 ## Quick Start
 
@@ -141,7 +138,7 @@ npm run build
 - **Language**: TypeScript
 - **Styling**: TailwindCSS
 - **Maps**: MapLibre GL
-- **Fonts**: Geist Sans & Mono
+- **Fonts**: Karla (body) & Poppins (headings), loaded via `next/font/google`
 
 ## License
 

--- a/hsdirectory/src/app/globals.css
+++ b/hsdirectory/src/app/globals.css
@@ -31,6 +31,9 @@
   --footer-social-bg: #c24532;
   --border-width: 4px;
 
+  /* Baseline font variables — next/font overrides these on body via CSS class */
+  --font-karla: Karla, sans-serif;
+  --font-poppins: Poppins, sans-serif;
   --font-header: var(--font-poppins), sans-serif;
   --font-body: var(--font-karla), sans-serif;
 }
@@ -47,8 +50,6 @@
   --color-card-border: var(--card-border);
   --color-muted: var(--muted);
   --color-section-alt: var(--section-alt);
-  --font-sans: var(--font-karla), system-ui, sans-serif;
-  --font-display: var(--font-poppins), sans-serif;
 }
 
 /* No dark mode — matches mutualaid.nyc light-only design */

--- a/hsdirectory/src/app/globals.css
+++ b/hsdirectory/src/app/globals.css
@@ -86,8 +86,10 @@ h2 {
   line-height: 1.4;
 }
 
-a {
-  color: var(--primary);
+@layer base {
+  a {
+    color: var(--primary);
+  }
 }
 
 /* Focus styles that work on all background colors and removes the default browser outline to prevent doubling */
@@ -143,4 +145,32 @@ a {
   font-size: 1.5rem;
   margin: 0.25rem 0.25rem 0;
   padding: 0.5rem;
+}
+
+/* MapLibre popup content */
+.popup-content {
+  padding: 8px;
+  max-width: 220px;
+}
+
+.popup-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--foreground);
+  font-size: 14px;
+}
+
+.popup-org {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 2px;
+}
+
+.popup-link {
+  color: var(--primary);
+  font-size: 12px;
+  text-decoration: underline;
+  display: inline-block;
+  margin-top: 4px;
 }

--- a/hsdirectory/src/app/globals.css
+++ b/hsdirectory/src/app/globals.css
@@ -47,8 +47,6 @@
   --color-card-border: var(--card-border);
   --color-muted: var(--muted);
   --color-section-alt: var(--section-alt);
-  --color-nav-bg: var(--nav-bg);
-  --color-nav-text: var(--nav-text);
   --font-sans: var(--font-karla), system-ui, sans-serif;
   --font-display: var(--font-poppins), sans-serif;
 }
@@ -138,6 +136,18 @@ h2 {
 /* Display font utility */
 .font-display {
   font-family: var(--font-display);
+}
+
+/* Nav link — shared style for header navigation links */
+.nav-link {
+  font-size: 18px;
+  line-height: 1.4;
+  font-weight: 600;
+  color: var(--nav-text);
+}
+
+.nav-link:hover {
+  text-decoration: underline;
 }
 
 .maplibregl-popup-close-button {

--- a/hsdirectory/src/app/globals.css
+++ b/hsdirectory/src/app/globals.css
@@ -135,11 +135,6 @@ h2 {
   background: rgba(32, 64, 69, 0.35);
 }
 
-/* Display font utility */
-.font-display {
-  font-family: var(--font-display);
-}
-
 /* Buttons — matches mutualaid.nyc style */
 .btn {
   font-family: var(--font-header);

--- a/hsdirectory/src/app/globals.css
+++ b/hsdirectory/src/app/globals.css
@@ -1,7 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  /* Exact mutualaid.nyc palette */
+  /* mutualaid.nyc palette */
+  --color-white: #ffffff;
   --background: #f5efe0;
   --foreground: #000000;
   --primary: #8F2D24;
@@ -14,7 +15,7 @@
   --highlight: #f7cf56;
   --highlight-alt: #a4cacb;
   --highlight-alt-bg: #ebf3f3;
-  --card-bg: #FFFFFF;
+  --card-bg: var(--color-white);
   --card-border: #E8E2DA;
   --muted: #586069;
   --section-alt: #ede8e1;
@@ -27,7 +28,7 @@
   --tag-gold-bg: #fdf7e6;
   --tag-gold-text: #6b5a1e;
   --nav-bg: #204045;
-  --nav-text: #FFFFFF;
+  --nav-text: var(--color-white);
   --footer-social-bg: #c24532;
   --border-width: 4px;
 
@@ -92,7 +93,7 @@ h2 {
 
 /* Focus styles that work on all background colors and removes the default browser outline to prevent doubling */
 *:focus-visible {
-  box-shadow: 0 0 0 2px #ffffff,
+  box-shadow: 0 0 0 2px var(--color-white),
               0 0 0 4px var(--primary);
   outline: none;
 }
@@ -137,6 +138,48 @@ h2 {
 /* Display font utility */
 .font-display {
   font-family: var(--font-display);
+}
+
+/* Buttons — matches mutualaid.nyc style */
+.btn {
+  font-family: var(--font-header);
+  font-weight: 600;
+  border-radius: 1000px;
+  padding: 0.75rem 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.2s ease;
+  text-decoration: none;
+  cursor: pointer;
+  border: 2px solid transparent;
+  line-height: 1.2;
+}
+
+.btn:hover {
+  opacity: 0.7;
+  text-decoration: none;
+}
+
+/* Filled teal — "primary" action */
+.btn-primary {
+  background-color: var(--secondary);
+  color: var(--color-white);
+  border-color: var(--secondary);
+}
+
+/* Outline purple — "secondary" action */
+.btn-secondary {
+  background-color: transparent;
+  color: var(--tertiary);
+  border-color: var(--tertiary);
+}
+
+/* Light teal fill — "accent" action */
+.btn-accent {
+  background-color: var(--highlight-alt);
+  color: var(--secondary);
+  border-color: var(--highlight-alt);
 }
 
 /* Nav link — shared style for header navigation links */

--- a/hsdirectory/src/app/globals.css
+++ b/hsdirectory/src/app/globals.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Karla:ital,wght@0,200..800;1,200..800&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 @import "tailwindcss";
 
 :root {
@@ -32,8 +31,8 @@
   --footer-social-bg: #c24532;
   --border-width: 4px;
 
-  --font-header: "Poppins", sans-serif;
-  --font-body: "Karla", sans-serif;
+  --font-header: var(--font-poppins), sans-serif;
+  --font-body: var(--font-karla), sans-serif;
 }
 
 @theme inline {
@@ -50,8 +49,8 @@
   --color-section-alt: var(--section-alt);
   --color-nav-bg: var(--nav-bg);
   --color-nav-text: var(--nav-text);
-  --font-sans: "Karla", system-ui, sans-serif;
-  --font-display: "Poppins", sans-serif;
+  --font-sans: var(--font-karla), system-ui, sans-serif;
+  --font-display: var(--font-poppins), sans-serif;
 }
 
 /* No dark mode — matches mutualaid.nyc light-only design */

--- a/hsdirectory/src/app/layout.tsx
+++ b/hsdirectory/src/app/layout.tsx
@@ -1,17 +1,19 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Karla, Poppins } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/ui/Header";
 import { Footer } from "@/components/ui/Footer";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const karla = Karla({
+  variable: "--font-karla",
   subsets: ["latin"],
+  weight: ["200", "300", "400", "500", "600", "700", "800"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const poppins = Poppins({
+  variable: "--font-poppins",
   subsets: ["latin"],
+  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
 });
 
 export const metadata: Metadata = {
@@ -31,7 +33,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
+        className={`${karla.variable} ${poppins.variable} antialiased min-h-screen flex flex-col`}
       >
         <a
           href="#main-content" className="absolute left-1 top-0 z-[100] bg-white transform -translate-y-full py-4 px-6 

--- a/hsdirectory/src/app/layout.tsx
+++ b/hsdirectory/src/app/layout.tsx
@@ -7,13 +7,13 @@ import { Footer } from "@/components/ui/Footer";
 const karla = Karla({
   variable: "--font-karla",
   subsets: ["latin"],
-  weight: ["200", "300", "400", "500", "600", "700", "800"],
+  weight: ["400", "500", "600", "700"],
 });
 
 const poppins = Poppins({
   variable: "--font-poppins",
   subsets: ["latin"],
-  weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+  weight: ["600", "700", "900"],
 });
 
 export const metadata: Metadata = {

--- a/hsdirectory/src/app/not-found.tsx
+++ b/hsdirectory/src/app/not-found.tsx
@@ -28,20 +28,10 @@ export default function NotFound() {
 
                 {/* Actions */}
                 <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                    <Link
-                        href="/"
-                        className="inline-flex items-center justify-center px-6 py-3 rounded-xl 
-              border border-[var(--card-border)] text-[var(--foreground)] opacity-70
-              hover:bg-[var(--section-alt)] hover:opacity-100 transition-all"
-                    >
+                    <Link href="/" className="btn btn-primary">
                         Back To Homepage
                     </Link>
-                    <Link
-                        href="/services"
-                        className="inline-flex items-center justify-center px-6 py-3 rounded-xl 
-              border border-[var(--card-border)] text-[var(--foreground)] opacity-70
-              hover:bg-[var(--section-alt)] hover:opacity-100 transition-all"
-                    >
+                    <Link href="/services" className="btn btn-primary">
                         Search For Resources
                     </Link>
                 </div>

--- a/hsdirectory/src/app/not-found.tsx
+++ b/hsdirectory/src/app/not-found.tsx
@@ -16,7 +16,7 @@ export default function NotFound() {
                 </div>
 
                 {/* Title */}
-                <h1 className="font-display text-4xl font-bold text-[var(--foreground)] mb-4">
+                <h1 className="text-4xl font-bold text-[var(--foreground)] mb-4">
                     404 - Page Not Found
                 </h1>
 

--- a/hsdirectory/src/app/not-found.tsx
+++ b/hsdirectory/src/app/not-found.tsx
@@ -21,7 +21,7 @@ export default function NotFound() {
                 </h1>
 
                 {/* Description */}
-                <p className="text-[var(--muted)] mb-8">
+                <p className="text-[var(--foreground)] mb-8">
                     Sorry, we couldn&apos;t find the page you&apos;re looking for.
                     It may have been moved or deleted.
                 </p>

--- a/hsdirectory/src/app/organizations/[id]/OrgLocationsMap.tsx
+++ b/hsdirectory/src/app/organizations/[id]/OrgLocationsMap.tsx
@@ -36,7 +36,7 @@ interface OrgLocationsMapProps {
  */
 export default function OrgLocationsMap({ locations }: OrgLocationsMapProps) {
     return (
-        <div style={{ height: '300px' }}>
+        <div className="h-[300px]">
             <MapViewDynamic locations={locations} />
         </div>
     );

--- a/hsdirectory/src/app/organizations/[id]/page.tsx
+++ b/hsdirectory/src/app/organizations/[id]/page.tsx
@@ -248,9 +248,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
                         {/* Back Button */}
                         <Link
                             href="/organizations"
-                            className="flex items-center justify-center gap-2 w-full py-3 px-4 rounded-xl
-                border border-[var(--card-border)] text-[var(--foreground)] opacity-70
-                hover:bg-[var(--section-alt)] hover:opacity-100 transition-all"
+                            className="btn btn-secondary w-full gap-2"
                         >
                             <svg className="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />

--- a/hsdirectory/src/app/organizations/[id]/page.tsx
+++ b/hsdirectory/src/app/organizations/[id]/page.tsx
@@ -146,7 +146,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
                                     Description
                                 </h2>
                                 <div className="prose max-w-none">
-                                    <p className="text-[var(--muted)] whitespace-pre-wrap">
+                                    <p className="text-[var(--foreground)] whitespace-pre-wrap">
                                         {organization.description}
                                     </p>
                                 </div>
@@ -227,7 +227,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
                                 {organization.email && (
                                     <a
                                         href={`mailto:${organization.email}`}
-                                        className="flex items-center gap-3 text-[var(--muted)] hover:text-[var(--foreground)]"
+                                        className="flex items-center gap-3 text-[var(--foreground)] hover:text-[var(--primary)]"
                                     >
                                         <svg className="w-5 h-5 shrink-0" role="img" aria-label="email" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}

--- a/hsdirectory/src/app/organizations/[id]/page.tsx
+++ b/hsdirectory/src/app/organizations/[id]/page.tsx
@@ -135,7 +135,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
                     {/* Group Header */}
                     <div>
                         {/* Name */}
-                        <h1 className="font-display text-3xl font-bold text-[var(--foreground)] mb-4">
+                        <h1 className="text-3xl font-bold text-[var(--foreground)] mb-4">
                             {organization.name}
                         </h1>
 
@@ -156,7 +156,7 @@ export default async function OrganizationDetailPage({ params }: OrganizationDet
 
                     {/* Resources Section */}
                     <section>
-                        <h2 className="font-display text-2xl font-bold text-[var(--foreground)] mb-6">
+                        <h2 className="text-2xl font-bold text-[var(--foreground)] mb-6">
                             Resources ({relatedServices.length})
                         </h2>
 

--- a/hsdirectory/src/app/organizations/page.tsx
+++ b/hsdirectory/src/app/organizations/page.tsx
@@ -47,7 +47,7 @@ export default async function OrganizationsPage({ searchParams }: OrganizationsP
                 <h1 className="font-display text-3xl font-bold text-[var(--foreground)] mb-4">
                     Groups
                 </h1>
-                <p className="text-[var(--muted)]">
+                <p className="text-[var(--foreground)]">
                     {totalItems.toLocaleString()} {totalItems === 1 ? 'group' : 'groups'} providing community resources{query && ` for search term "${query}"`}
                 </p>
             </div>
@@ -76,7 +76,7 @@ export default async function OrganizationsPage({ searchParams }: OrganizationsP
                     <h3 className="text-lg font-medium text-[var(--foreground)] mb-2">
                         {query ? `No results for "${query}"` : "No groups found"}
                     </h3>
-                    <p className="text-[var(--muted)]">
+                    <p className="text-[var(--foreground)]">
                         {query ? "Try a different search term." : "No groups are currently available."}
                     </p>
                 </div>

--- a/hsdirectory/src/app/organizations/page.tsx
+++ b/hsdirectory/src/app/organizations/page.tsx
@@ -44,7 +44,7 @@ export default async function OrganizationsPage({ searchParams }: OrganizationsP
         <div className="container mx-auto px-4 py-8">
             {/* Page Header */}
             <div className="mb-8">
-                <h1 className="font-display text-3xl font-bold text-[var(--foreground)] mb-4">
+                <h1 className="text-3xl font-bold text-[var(--foreground)] mb-4">
                     Groups
                 </h1>
                 <p className="text-[var(--foreground)]">

--- a/hsdirectory/src/app/page.tsx
+++ b/hsdirectory/src/app/page.tsx
@@ -46,7 +46,7 @@ export default async function Home() {
           </div>
           <div className="max-w-3xl mx-auto text-center">
             <p className="text-xl mb-5">
-              Search our directory of {stats.resources.toLocaleString()} resources
+              Search the directory of {stats.resources.toLocaleString()} resources
               from {stats.groups.toLocaleString()} groups
             </p>
           </div>
@@ -55,10 +55,10 @@ export default async function Home() {
           </div>
           <div className="flex justify-center gap-4 mt-10">
             <a href="https://mutualaid.nyc/submit-a-resource/" className="btn btn-primary">
-              Submit a resource
+              Submit a Resource
             </a>
             <a href="https://mutualaid.nyc/suggest-a-change/" className="btn btn-primary">
-              Suggest a change
+              Suggest a Change
             </a>
           </div>
         </div>

--- a/hsdirectory/src/app/page.tsx
+++ b/hsdirectory/src/app/page.tsx
@@ -38,10 +38,10 @@ export default async function Home() {
             <h1 className="font-display text-5xl md:text-6xl font-bold text-[var(--secondary)] mb-6">
               Mutual Aid <span className="bg-[var(--highlight)] text-[var(--tertiary)] px-2">NYC</span>
             </h1>
-            <p className="text-xl text-[var(--muted)] mb-4">
+            <p className="text-xl text-[var(--foreground)] mb-4">
               We help build and strengthen local mutual aid networks.
             </p>
-            <p className="text-lg text-[var(--muted)] mb-10">
+            <p className="text-lg text-[var(--foreground)] mb-10">
               Search our directory of {stats.resources.toLocaleString()} resources 
               from {stats.groups.toLocaleString()} groups
             </p>

--- a/hsdirectory/src/app/page.tsx
+++ b/hsdirectory/src/app/page.tsx
@@ -32,7 +32,7 @@ export default async function Home() {
   return (
     <div className="flex flex-col">
       {/* Hero Section */}
-      <section className="pt-10 pb-12 md:py-30 px-4 bg-[var(--background)]">
+      <section className="pt-10 pb-12 md:py-28 px-4 bg-[var(--background)]">
         <div className="container mx-auto">
           <div className="max-w-5xl mx-auto text-center">
             <h1 className="font-black text-4xl md:text-6xl text-[var(--secondary)] mb-6">

--- a/hsdirectory/src/app/page.tsx
+++ b/hsdirectory/src/app/page.tsx
@@ -2,19 +2,6 @@ import Link from "next/link";
 import { SearchBar } from "@/components/ui/SearchBar";
 import { getServices, getOrganizations, getMapServices } from "@/lib/api";
 
-/**
- * Warm earthy color palette for category cards (mutualaid.nyc style).
- */
-const CARD_COLORS = [
-  { bg: "bg-[#fce8e5]", text: "text-[#8F2D24]" },
-  { bg: "bg-[#ebf3f3]", text: "text-[#204045]" },
-  { bg: "bg-[#fdf7e6]", text: "text-[#6b5a1e]" },
-  { bg: "bg-[#f3ebf1]", text: "text-[#47133d]" },
-  { bg: "bg-[#e6f0e8]", text: "text-[#204045]" },
-  { bg: "bg-[#fce8e5]", text: "text-[#8F2D24]" },
-  { bg: "bg-[#ebf3f3]", text: "text-[#204045]" },
-  { bg: "bg-[#fdf7e6]", text: "text-[#6b5a1e]" },
-];
 
 /** Terms to exclude from the homepage grid. */
 const EXCLUDED_TERMS = new Set(["-Not Listed", "Not Listed"]);
@@ -72,8 +59,7 @@ export default async function Home() {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto">
             <Link
               href="/services"
-              className="group flex flex-col items-center gap-3 p-8 rounded-2xl bg-[var(--primary)] hover:bg-[var(--primary-hover)] shadow-md hover:shadow-lg transition-all"
-              style={{ color: "#FFFFFF" }}
+              className="group flex flex-col items-center gap-3 p-8 rounded-2xl bg-[var(--primary)] hover:bg-[var(--primary-hover)] shadow-md hover:shadow-lg transition-all text-white"
             >
               <svg className="w-8 h-8" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
@@ -84,8 +70,7 @@ export default async function Home() {
 
             <Link
               href="https://mutualaid.nyc/get-involved/"
-              className="group flex flex-col items-center gap-3 p-8 rounded-2xl bg-[var(--secondary)] hover:bg-[var(--secondary-hover)] shadow-md hover:shadow-lg transition-all"
-              style={{ color: "#FFFFFF" }}
+              className="group flex flex-col items-center gap-3 p-8 rounded-2xl bg-[var(--secondary)] hover:bg-[var(--secondary-hover)] shadow-md hover:shadow-lg transition-all text-white"
             >
               <svg className="w-8 h-8" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
@@ -96,8 +81,7 @@ export default async function Home() {
 
             <Link
               href="https://mutualaid.nyc/for-groups-organizers/"
-              className="group flex flex-col items-center gap-3 p-8 rounded-2xl bg-[var(--tertiary)] hover:opacity-80 shadow-md hover:shadow-lg transition-all"
-              style={{ color: "#FFFFFF" }}
+              className="group flex flex-col items-center gap-3 p-8 rounded-2xl bg-[var(--tertiary)] hover:opacity-80 shadow-md hover:shadow-lg transition-all text-white"
             >
               <svg className="w-8 h-8" aria-hidden="true"fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
@@ -125,13 +109,12 @@ export default async function Home() {
               </Link>
             </div>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-              {categories.map((category, index) => {
-                const color = CARD_COLORS[index % CARD_COLORS.length];
+              {categories.map((category) => {
                 return (
                   <Link
                     key={category.name}
                     href={`/services?category=${encodeURIComponent(category.name)}`}
-                    className={`group flex items-center gap-3 p-5 rounded-2xl ${color.bg} border border-[var(--card-border)] hover:shadow-md transition-all`}
+                    className="group flex items-center gap-3 p-5 rounded-2xl bg-card-bg border border-[var(--card-border)] hover:shadow-md transition-all"
                   >
                     <span className="flex-shrink-0 w-8 h-8 flex items-center justify-center">
                       {category.icon ? (
@@ -145,7 +128,7 @@ export default async function Home() {
                         <span className="w-6 h-6 rounded-full bg-black/10 block" />
                       )}
                     </span>
-                    <span className={`text-sm font-semibold ${color.text}`}>
+                    <span className="text-sm font-semibold text-foreground">
                       {category.name}
                     </span>
                   </Link>

--- a/hsdirectory/src/app/page.tsx
+++ b/hsdirectory/src/app/page.tsx
@@ -7,7 +7,7 @@ import { getServices, getOrganizations, getMapServices } from "@/lib/api";
 const EXCLUDED_TERMS = new Set(["-Not Listed", "Not Listed"]);
 
 /**
- * Homepage with warm community-oriented design inspired by mutualaid.nyc.
+ * Homepage based on mutualaid.nyc.
  */
 export default async function Home() {
   let stats = { resources: 0, groups: 0 };
@@ -31,71 +31,42 @@ export default async function Home() {
 
   return (
     <div className="flex flex-col">
-      {/* Hero Section — warm cream with serif heading */}
-      <section className="py-24 px-4 bg-[var(--background)]">
+      {/* Hero Section */}
+      <section className="pt-10 pb-12 md:py-30 px-4 bg-[var(--background)]">
         <div className="container mx-auto">
-          <div className="max-w-3xl mx-auto text-center">
-            <h1 className="font-display text-5xl md:text-6xl font-bold text-[var(--secondary)] mb-6">
-              Mutual Aid <span className="bg-[var(--highlight)] text-[var(--tertiary)] px-2">NYC</span>
+          <div className="max-w-5xl mx-auto text-center">
+            <h1 className="font-black text-4xl md:text-6xl text-[var(--secondary)] mb-6">
+              Community Resources Library
             </h1>
-            <p className="text-xl text-[var(--foreground)] mb-4">
-              We help build and strengthen local mutual aid networks.
+          </div>
+          <div className="max-w-3xl mb-10 mx-auto">
+            <p className="text-2xl font-bold text-[var(--primary)] mb-4">
+              Our community-sourced, volunteer-curated library is a collection of the many resources available to New Yorkers.
             </p>
-            <p className="text-lg text-[var(--foreground)] mb-10">
-              Search our directory of {stats.resources.toLocaleString()} resources 
+          </div>
+          <div className="max-w-3xl mx-auto text-center">
+            <p className="text-xl mb-5">
+              Search our directory of {stats.resources.toLocaleString()} resources
               from {stats.groups.toLocaleString()} groups
             </p>
-            <SearchBar placeholder="What resource are you looking for?" />
+          </div>
+          <div className="flex justify-center">
+            <SearchBar placeholder="Search resources..." />
+          </div>
+          <div className="flex justify-center gap-4 mt-10">
+            <a href="https://mutualaid.nyc/submit-a-resource/" className="btn btn-primary">
+              Submit a resource
+            </a>
+            <a href="https://mutualaid.nyc/suggest-a-change/" className="btn btn-primary">
+              Suggest a change
+            </a>
           </div>
         </div>
       </section>
 
-      {/* I am... CTA Section */}
-      <section className="py-12 px-4 bg-[var(--section-alt)]">
-        <div className="container mx-auto">
-          <h2 className="font-display text-2xl font-bold text-center text-[var(--foreground)] mb-8">
-            I am…
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto">
-            <Link
-              href="/services"
-              className="group flex flex-col items-center gap-3 p-8 rounded-2xl bg-[var(--primary)] hover:bg-[var(--primary-hover)] shadow-md hover:shadow-lg transition-all text-white"
-            >
-              <svg className="w-8 h-8" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-              <span className="text-lg font-semibold">looking for HELP</span>
-            </Link>
-
-            <Link
-              href="https://mutualaid.nyc/get-involved/"
-              className="group flex flex-col items-center gap-3 p-8 rounded-2xl bg-[var(--secondary)] hover:bg-[var(--secondary-hover)] shadow-md hover:shadow-lg transition-all text-white"
-            >
-              <svg className="w-8 h-8" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                 d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-              </svg>
-              <span className="text-lg font-semibold">looking to VOLUNTEER</span>
-            </Link>
-
-            <Link
-              href="https://mutualaid.nyc/for-groups-organizers/"
-              className="group flex flex-col items-center gap-3 p-8 rounded-2xl bg-[var(--tertiary)] hover:opacity-80 shadow-md hover:shadow-lg transition-all text-white"
-            >
-              <svg className="w-8 h-8" aria-hidden="true"fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} 
-                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-              <span className="text-lg font-semibold">a GROUP/ORGANIZER</span>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Resource Categories — warm earthy colored cards */}
+      {/* Resource Categories  */}
       {categories.length > 0 && (
-        <section className="py-16 px-4">
+        <section className="pt-10 pb-16 px-4 bg-[var(--section-alt)]">
           <div className="container mx-auto">
             <div className="flex items-center justify-between mb-8">
               <h2 className="font-display text-2xl font-bold text-[var(--foreground)]">

--- a/hsdirectory/src/app/page.tsx
+++ b/hsdirectory/src/app/page.tsx
@@ -69,7 +69,7 @@ export default async function Home() {
         <section className="pt-10 pb-16 px-4 bg-[var(--section-alt)]">
           <div className="container mx-auto">
             <div className="flex items-center justify-between mb-8">
-              <h2 className="font-display text-2xl font-bold text-[var(--foreground)]">
+              <h2 className="text-2xl font-bold text-[var(--foreground)]">
                 Browse By Category
               </h2>
               <Link

--- a/hsdirectory/src/app/services/MapPageClient.tsx
+++ b/hsdirectory/src/app/services/MapPageClient.tsx
@@ -530,7 +530,7 @@ function ResourceCard({ service, userLocation, onViewOnMap }: {
 
             {service.phone && (
                 <p className="text-sm text-[var(--foreground)] mb-1 flex items-center gap-2">
-                    <svg className="w-4 h-4 flex-shrink-0" role="img"aria-label="phone" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-4 h-4 flex-shrink-0" role="img" aria-label="phone" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
                     </svg>
                     <a href={`tel:${service.phone}`} className="underline hover:no-underline hover:text-[var(--primary)]">{service.phone}</a>
@@ -539,7 +539,7 @@ function ResourceCard({ service, userLocation, onViewOnMap }: {
 
             {service.url && (
                 <p className="text-sm text-[var(--foreground)] mb-2 flex items-center gap-2">
-                    <svg className="w-4 h-4 flex-shrink-0" role="img"aria-label="website" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-4 h-4 flex-shrink-0" role="img" aria-label="website" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
                     </svg>
                     <a

--- a/hsdirectory/src/app/services/MapPageClient.tsx
+++ b/hsdirectory/src/app/services/MapPageClient.tsx
@@ -445,7 +445,7 @@ export default function MapPageClient({
                 )}
 
                 {/* Results count */}
-                <div className="mt-4 text-sm text-[var(--muted)]">
+                <div className="mt-4 text-sm text-[var(--foreground)]">
                     {filteredServices.length} resources found
                 </div>
             </div>
@@ -454,7 +454,7 @@ export default function MapPageClient({
             <div className={`${viewMode === 'list' ? 'block' : 'hidden'} md:block w-full md:w-[32rem] flex-1 flex-shrink-0 border-r border-[var(--card-border)] overflow-y-auto scrollbar-thin`}>
                 <div className="p-4 space-y-4">
                     {filteredServices.length === 0 ? (
-                        <div className="text-center py-8 text-[var(--muted)]">
+                        <div className="text-center py-8 text-[var(--foreground)]">
                             No resources match your filters
                         </div>
                     ) : (
@@ -511,7 +511,7 @@ function ResourceCard({ service, userLocation, onViewOnMap }: {
             </div>
 
             {service.address && (
-                <div className="text-sm text-[var(--muted)] mb-2 flex items-start justify-between gap-2">
+                <div className="text-sm text-[var(--foreground)] mb-2 flex items-start justify-between gap-2">
                     <div className="flex items-start gap-2">
                         <svg className="w-4 h-4 mt-0.5 flex-shrink-0" role="img" aria-label="address" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
@@ -529,7 +529,7 @@ function ResourceCard({ service, userLocation, onViewOnMap }: {
             )}
 
             {service.phone && (
-                <p className="text-sm text-[var(--muted)] mb-1 flex items-center gap-2">
+                <p className="text-sm text-[var(--foreground)] mb-1 flex items-center gap-2">
                     <svg className="w-4 h-4 flex-shrink-0" role="img"aria-label="phone" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
                     </svg>
@@ -538,7 +538,7 @@ function ResourceCard({ service, userLocation, onViewOnMap }: {
             )}
 
             {service.url && (
-                <p className="text-sm text-[var(--muted)] mb-2 flex items-center gap-2">
+                <p className="text-sm text-[var(--foreground)] mb-2 flex items-center gap-2">
                     <svg className="w-4 h-4 flex-shrink-0" role="img"aria-label="website" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
                     </svg>
@@ -554,7 +554,7 @@ function ResourceCard({ service, userLocation, onViewOnMap }: {
             )}
 
             {service.description && (
-                <p className="text-sm text-[var(--muted)] mb-3 line-clamp-2">
+                <p className="text-sm text-[var(--foreground)] mb-3 line-clamp-2">
                     {service.description}
                 </p>
             )}

--- a/hsdirectory/src/app/services/MapPageClient.tsx
+++ b/hsdirectory/src/app/services/MapPageClient.tsx
@@ -504,7 +504,7 @@ function ResourceCard({ service, userLocation, onViewOnMap }: {
                     {service.name}
                 </h3>
                 {distance !== null && (
-                    <span className="flex-shrink-0 text-xs font-medium text-[var(--secondary)] bg-[var(--tag-blue-bg)] px-2 py-0.5 rounded-full whitespace-nowrap">
+                    <span className="flex-shrink-0 text-xs font-medium text-[var(--secondary)] bg-[var(--tag-blue-bg)] border border-[var(--tag-blue-text)] px-2 py-0.5 rounded-full whitespace-nowrap">
                         {distance < 0.1 ? '< 0.1' : distance.toFixed(1)} mi
                     </span>
                 )}

--- a/hsdirectory/src/app/services/MapPageClient.tsx
+++ b/hsdirectory/src/app/services/MapPageClient.tsx
@@ -438,7 +438,7 @@ export default function MapPageClient({
                 {(searchQuery || selectedNeed || selectedCommunity || selectedBorough) && (
                     <button
                         onClick={handleClearFilters}
-                        className="w-full px-4 py-2 text-sm text-[var(--primary)] hover:text-[var(--primary-hover)] hover:bg-[var(--tag-coral-bg)] rounded-lg transition-colors"
+                        className="btn btn-accent w-full"
                     >
                         Clear All Filters
                     </button>

--- a/hsdirectory/src/app/services/[id]/page.tsx
+++ b/hsdirectory/src/app/services/[id]/page.tsx
@@ -341,9 +341,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                         {/* Back Button */}
                         <Link
                             href="/services"
-                            className="flex items-center justify-center gap-2 w-full py-3 px-4 rounded-xl 
-                border border-[var(--card-border)] text-[var(--foreground)] opacity-70
-                hover:bg-[var(--section-alt)] hover:opacity-100 transition-all"
+                            className="btn btn-secondary w-full gap-2"
                         >
                             <svg className="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />

--- a/hsdirectory/src/app/services/[id]/page.tsx
+++ b/hsdirectory/src/app/services/[id]/page.tsx
@@ -138,7 +138,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
 
                         {/* Group/Organization Name - linked to org profile */}
                         {(service.group_name || service.organization) && (
-                            <p className="text-lg text-[var(--muted)] mb-4">
+                            <p className="text-lg text-[var(--foreground)] mb-4">
                                 <span className="font-medium">Group:</span>{' '}
                                 {resolvedOrgId ? (
                                     <Link
@@ -201,7 +201,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                                 Description
                             </h2>
                             <div className="prose max-w-none">
-                                <p className="text-[var(--muted)] whitespace-pre-wrap">
+                                <p className="text-[var(--foreground)] whitespace-pre-wrap">
                                     {service.description}
                                 </p>
                             </div>
@@ -228,7 +228,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                                                     </h3>
                                                 )}
                                                 {sal.location.addresses?.length > 0 && (
-                                                    <div className="text-[var(--muted)]">
+                                                    <div className="text-[var(--foreground)]">
                                                         {sal.location.addresses.map((addr: any) => (
                                                             <p key={addr.id}>
                                                                 {[addr.address_1, addr.address_2, addr.city, addr.state_province, addr.postal_code]
@@ -260,7 +260,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                                 />
                                 {mapCoords.address && (
                                     <div className="p-4 border-t border-[var(--card-border)]">
-                                        <p className="text-sm text-[var(--muted)] mb-2">
+                                        <p className="text-sm text-[var(--foreground)] mb-2">
                                             {mapCoords.address}
                                         </p>
                                         <a
@@ -305,7 +305,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                                 {service.email && (
                                     <a
                                         href={`mailto:${service.email}`}
-                                        className="flex items-center gap-3 text-[var(--muted)] hover:text-[var(--foreground)]"
+                                        className="flex items-center gap-3 text-[var(--foreground)] hover:text-[var(--primary)]"
                                     >
                                         <svg className="w-5 h-5 shrink-0" role="img" aria-label="email" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
@@ -316,7 +316,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                                 )}
 
                                 {(service.phones?.length ?? 0) > 0 && service.phones!.map((phone: any) => (
-                                    <div key={phone.id} className="flex items-center gap-3 text-[var(--muted)]">
+                                    <div key={phone.id} className="flex items-center gap-3 text-[var(--foreground)]">
                                         <svg className="w-5 h-5 shrink-0" role="img"aria-label="phone" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
                                         </svg>

--- a/hsdirectory/src/app/services/[id]/page.tsx
+++ b/hsdirectory/src/app/services/[id]/page.tsx
@@ -131,7 +131,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
                     {/* Header */}
                     <div>
                         <div className="flex items-start justify-between gap-4 mb-4">
-                            <h1 className="font-display text-3xl font-bold text-[var(--foreground)]">
+                            <h1 className="text-3xl font-bold text-[var(--foreground)]">
                                 {service.name}
                             </h1>
                         </div>

--- a/hsdirectory/src/app/services/[id]/page.tsx
+++ b/hsdirectory/src/app/services/[id]/page.tsx
@@ -317,7 +317,7 @@ export default async function ServiceDetailPage({ params }: ServiceDetailPagePro
 
                                 {(service.phones?.length ?? 0) > 0 && service.phones!.map((phone: any) => (
                                     <div key={phone.id} className="flex items-center gap-3 text-[var(--foreground)]">
-                                        <svg className="w-5 h-5 shrink-0" role="img"aria-label="phone" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <svg className="w-5 h-5 shrink-0" role="img" aria-label="phone" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
                                         </svg>
                                         <span>

--- a/hsdirectory/src/components/map/MapView.tsx
+++ b/hsdirectory/src/components/map/MapView.tsx
@@ -87,9 +87,9 @@ export default function MapView({ locations, highlightedId }: MapViewProps) {
             sources: {
                 osm: {
                     type: 'raster',
-                    tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+                    tiles: ['https://basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'],
                     tileSize: 256,
-                    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+                    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
                 },
             },
             layers: [{

--- a/hsdirectory/src/components/map/MapView.tsx
+++ b/hsdirectory/src/components/map/MapView.tsx
@@ -57,7 +57,6 @@ function toGeoJSON(locations: MapLocation[]): GeoJSON.FeatureCollection {
             properties: {
                 id: loc.serviceId || loc.id,
                 name: loc.serviceName || loc.name,
-                locationName: loc.name,
                 serviceId: loc.serviceId || '',
                 orgName: loc.orgName || '',
             },
@@ -187,20 +186,12 @@ export default function MapView({ locations, highlightedId }: MapViewProps) {
                 const popup = new maplibregl.Popup({ offset: [0, -PIN_H] })
                     .setLngLat(coords)
                     .setHTML(`
-                        <div style="padding: 8px; max-width: 220px;">
-                            <h4 style="font-weight: 600; margin-bottom: 4px; color: #111; font-size: 14px;">
-                                ${props.name}
-                            </h4>
-                            ${props.orgName 
-                            ? `<p style="color: #444; font-size: 13px; font-weight: 500; margin-bottom: 2px;">${props.orgName}</p>`
+                        <div class="popup-content">
+                            <h4 class="popup-title">${props.name}</h4>
+                            ${props.orgName
+                            ? `<p class="popup-org">${props.orgName}</p>`
                             : ''}
-                            ${props.locationName && props.locationName !== props.name
-                            ? `<p style="color: #666; font-size: 12px; margin-bottom: 8px;">${props.locationName}</p>`
-                            : ''}
-                            <a href="${linkHref}"
-                               style="color: #8F2D24; font-size: 12px; text-decoration: underline; display: inline-block; margin-top: 4px;">
-                               ${linkText}
-                            </a>
+                            <a href="${linkHref}" class="popup-link">${linkText}</a>
                         </div>
                     `)
                     .addTo(map);
@@ -277,8 +268,7 @@ export default function MapView({ locations, highlightedId }: MapViewProps) {
     return (
         <div
             ref={mapContainer}
-            className="w-full h-full"
-            style={{ minHeight: '400px' }}
+            className="w-full h-full min-h-[400px]"
         />
     );
 }

--- a/hsdirectory/src/components/organizations/OrganizationCard.tsx
+++ b/hsdirectory/src/components/organizations/OrganizationCard.tsx
@@ -31,7 +31,7 @@ export function OrganizationCard({ organization }: OrganizationCardProps) {
             {/* Resource Count */}
             <div className="mt-3 flex flex-wrap gap-3 text-sm">
                 {organization.service_count !== undefined && organization.service_count > 0 && (
-                    <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-[var(--tag-olive-bg)] text-[var(--tag-olive-text)]">
+                    <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full bg-[var(--tag-olive-bg)] text-[var(--tag-olive-text)] border border-[var(--tag-olive-text)]">
                         <svg className="w-4 h-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                                 d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />

--- a/hsdirectory/src/components/organizations/OrganizationCard.tsx
+++ b/hsdirectory/src/components/organizations/OrganizationCard.tsx
@@ -22,7 +22,7 @@ export function OrganizationCard({ organization }: OrganizationCardProps) {
                 </h3>
                 {/* Description */}
                 {organization.description && (
-                    <p className="mt-2 text-[var(--muted)] line-clamp-3">
+                    <p className="mt-2 text-[var(--foreground)] line-clamp-3">
                         {organization.description}
                     </p>
                 )}

--- a/hsdirectory/src/components/services/ServiceCard.tsx
+++ b/hsdirectory/src/components/services/ServiceCard.tsx
@@ -28,7 +28,7 @@ export function ServiceCard({ service }: ServiceCardProps) {
 
                     {/* Group (Organization) */}
                     {service.organization && (
-                        <p className="mt-1 text-sm text-[var(--muted)] flex items-center gap-1">
+                        <p className="mt-1 text-sm text-[var(--foreground)] flex items-center gap-1">
                             <svg className="w-3.5 h-3.5 shrink-0" aria-label="group" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                                     d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -39,7 +39,7 @@ export function ServiceCard({ service }: ServiceCardProps) {
 
                     {/* Description */}
                     {service.description && (
-                        <p className="mt-3 text-[var(--muted)] line-clamp-2">
+                        <p className="mt-3 text-[var(--foreground)] line-clamp-2">
                             {service.description}
                         </p>
                     )}
@@ -55,7 +55,7 @@ export function ServiceCard({ service }: ServiceCardProps) {
                 if (parts.length === 0) return null;
                 return (
                     <div className="mt-4 pt-4 border-t border-[var(--card-border)]">
-                        <p className="text-sm text-[var(--muted)] flex items-center gap-1">
+                        <p className="text-sm text-[var(--foreground)] flex items-center gap-1">
                             <svg className="w-4 h-4 shrink-0" aria-label="address" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                                     d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />

--- a/hsdirectory/src/components/ui/Footer.tsx
+++ b/hsdirectory/src/components/ui/Footer.tsx
@@ -38,8 +38,7 @@ export function Footer() {
                             href="https://openreferral.org"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="hover:no-underline underline transition-opacity"
-                            style={{ color: 'inherit' }}
+                            className="hover:no-underline underline transition-opacity text-inherit"
                         >
                             Open Referral HSDS
                         </a>

--- a/hsdirectory/src/components/ui/Footer.tsx
+++ b/hsdirectory/src/components/ui/Footer.tsx
@@ -16,17 +16,11 @@ export function Footer() {
                     </div>
 
                     {/* Links */}
-                    <nav className="flex flex-wrap gap-6 text-sm">
-                        <Link 
-                            href="/services" 
-                            className="!text-white hover:!text-[var(--highlight)] hover:no-underline transition-all duration-200 font-medium"
-                        >
+                    <nav className="flex flex-wrap gap-6 text-sm]">
+                        <Link href="/services" className="text-[var(--nav-text)] underline hover:no-underline">
                             Resources
                         </Link>
-                        <Link 
-                            href="/organizations" 
-                            className="!text-white hover:!text-[var(--highlight)] hover:no-underline transition-all duration-200 font-medium"
-                        >
+                        <Link href="/organizations" className="text-[var(--nav-text)] underline hover:no-underline">
                             Groups
                         </Link>
                     </nav>

--- a/hsdirectory/src/components/ui/Footer.tsx
+++ b/hsdirectory/src/components/ui/Footer.tsx
@@ -16,7 +16,7 @@ export function Footer() {
                     </div>
 
                     {/* Links */}
-                    <nav className="flex flex-wrap gap-6 text-sm]">
+                    <nav className="flex flex-wrap gap-6 text-sm">
                         <Link href="/services" className="text-[var(--nav-text)] underline hover:no-underline">
                             Resources
                         </Link>

--- a/hsdirectory/src/components/ui/Footer.tsx
+++ b/hsdirectory/src/components/ui/Footer.tsx
@@ -32,7 +32,7 @@ export function Footer() {
                     </nav>
 
                     {/* Attribution */}
-                    <p className="text-sm text-[var(--nav-text)] opacity-50">
+                    <p className="text-sm text-[var(--nav-text)]">
                         Powered by{' '}
                         <a
                             href="https://openreferral.org"

--- a/hsdirectory/src/components/ui/Footer.tsx
+++ b/hsdirectory/src/components/ui/Footer.tsx
@@ -10,7 +10,7 @@ export function Footer() {
                 <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                     {/* Branding */}
                     <div className="flex items-center gap-2">
-                        <span className="font-display text-lg font-bold text-[var(--nav-text)]">
+                        <span className="text-lg font-bold text-[var(--nav-text)]">
                             Mutual Aid <span className="text-[var(--highlight)]">NYC</span>
                         </span>
                     </div>

--- a/hsdirectory/src/components/ui/Header.tsx
+++ b/hsdirectory/src/components/ui/Header.tsx
@@ -24,7 +24,7 @@ export function Header() {
                 <div className="flex h-[80px] xl:h-[160px] items-center justify-between mx-[42.36px]">
 
                     {/* Logo */}
-                    <Link href="/" className="flex items-center gap-3">
+                    <a href="https://mutualaid.nyc" className="flex items-center gap-3">
                         <Image
                             src="/logo.png"
                             alt="Mutual Aid NYC logo"
@@ -32,7 +32,7 @@ export function Header() {
                             height={130}
                             className="w-[60px] h-[60px] xl:w-[120px] xl:h-[120px]"
                         />
-                    </Link>
+                    </a>
 
                     {/* Hamburger — mobile only */}
                     <button

--- a/hsdirectory/src/components/ui/Header.tsx
+++ b/hsdirectory/src/components/ui/Header.tsx
@@ -1,56 +1,95 @@
+'use client';
+
+import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { SearchBar } from './SearchBar';
+import { NavSubmenu } from './NavSubmenu';
 
-interface HeaderProps {
-    showSearch?: boolean;
-}
+const ABOUT_ITEMS = [
+    { label: 'About Mutual Aid NYC', href: 'https://mutualaid.nyc/about/' },
+    { label: 'Guiding Principles', href: 'https://mutualaid.nyc/about/principles/' },
+];
 
 /**
- * Site header with navigation and optional search bar.
- * Dark teal background matching mutualaid.nyc (#204045).
+ * Site header that matches mutualaid.nyc.
  */
-export function Header({ showSearch = true }: HeaderProps) {
+export function Header() {
+    const [mobileOpen, setMobileOpen] = useState(false);
+
     return (
-        <header className="sticky top-0 z-50 w-full bg-[var(--nav-bg)]">
-            <div className="container mx-auto flex h-16 items-center justify-between px-4">
-                {/* Logo */}
-                <Link href="/" className="flex items-center gap-3">
-                    <Image
-                        src="/logo.png"
-                        alt="Mutual Aid NYC logo"
-                        width={60}
-                        height={60}
-                        className="rounded-full"
-                    />
-                    <span className="hidden md:inline font-display text-xl text-[var(--nav-text)] tracking-tight">
-                        Community Resources Library
-                    </span>
-                </Link>
+        <header className="w-full bg-[var(--nav-bg)]">
+            <div className="w-full px-[50px]">
 
-                {/* Search Bar (compact) */}
-                {showSearch && (
-                    <div className="hidden md:block flex-1 max-w-md mx-8">
-                        <SearchBar size="sm" placeholder="Search resources..." />
-                    </div>
+                {/* ── Header row */}
+                <div className="flex h-[80px] xl:h-[160px] items-center justify-between mx-[42.36px]">
+
+                    {/* Logo */}
+                    <Link href="/" className="flex items-center gap-3">
+                        <Image
+                            src="/logo.png"
+                            alt="Mutual Aid NYC logo"
+                            width={130}
+                            height={130}
+                            className="w-[60px] h-[60px] xl:w-[120px] xl:h-[120px]"
+                        />
+                    </Link>
+
+                    {/* Hamburger — mobile only */}
+                    <button
+                        aria-expanded={mobileOpen}
+                        aria-label="Toggle navigation"
+                        onClick={() => setMobileOpen(v => !v)}
+                        className="xl:hidden text-white p-2 -mr-2"
+                    >
+                        {mobileOpen ? (
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                                <path d="M18 6L6 18M6 6l12 12" />
+                            </svg>
+                        ) : (
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                                <path d="M3 6h18M3 12h18M3 18h18" />
+                            </svg>
+                        )}
+                    </button>
+
+                    {/* Desktop nav — always visible at xl+ */}
+                    <nav className="hidden xl:flex" aria-label="Main navigation">
+                        <ul className="flex items-center gap-[19.2px] list-none m-0 p-0">
+                            <li><Link href="/" className="nav-link">Community Resources Library</Link></li>
+                            <li><a href="https://mutualaid.nyc/mutual-aid-groups/" className="nav-link">Mutual aid groups</a></li>
+                            <li><a href="https://mutualaid.nyc/for-groups-organizers/" className="nav-link">For groups + organizers</a></li>
+                            <li><a href="https://mutualaid.nyc/get-involved/" className="nav-link">Volunteer</a></li>
+                            <li><NavSubmenu label="About" items={ABOUT_ITEMS} /></li>
+                        </ul>
+                    </nav>
+                </div>
+
+                {/* ── Mobile nav panel */}
+                {mobileOpen && (
+                    <nav
+                        aria-label="Mobile navigation"
+                        className="xl:hidden py-4 border-t border-white/20"
+                    >
+                        <ul className="flex flex-col gap-1 list-none m-0 p-0">
+                            <li>
+                                <Link href="/" className="nav-link block py-2" onClick={() => setMobileOpen(false)}>
+                                    Community Resources Library
+                                </Link>
+                            </li>
+                            <li><a href="https://mutualaid.nyc/mutual-aid-groups/" className="nav-link block py-2">Mutual aid groups</a></li>
+                            <li><a href="https://mutualaid.nyc/for-groups-organizers/" className="nav-link block py-2">For groups + organizers</a></li>
+                            <li><a href="https://mutualaid.nyc/get-involved/" className="nav-link block py-2">Volunteer</a></li>
+                            {/* About items shown flat on mobile — no hover submenu */}
+                            <li className="text-white/60 text-sm font-semibold tracking-tight pt-3 pb-1">About</li>
+                            {ABOUT_ITEMS.map(item => (
+                                <li key={item.href}>
+                                    <a href={item.href} className="nav-link block py-2 pl-3">{item.label}</a>
+                                </li>
+                            ))}
+                        </ul>
+                    </nav>
                 )}
-
-                {/* Navigation */}
-                <nav className="flex items-center gap-4 md:gap-6">
-                    <Link
-                        href="/services"
-                        className="text-sm font-semibold text-nav-text hover:text-[var(--highlight)] transition-colors tracking-tight"
-                    >
-                        Resources
-                    </Link>
-                    <Link
-                        href="/organizations"
-                        className="text-sm font-semibold text-nav-text hover:text-[var(--highlight)] transition-colors tracking-tight"
-                    >
-                        Groups
-                    </Link>
-                </nav>
-            </div >
-        </header >
+            </div>
+        </header>
     );
 }

--- a/hsdirectory/src/components/ui/Header.tsx
+++ b/hsdirectory/src/components/ui/Header.tsx
@@ -39,15 +39,13 @@ export function Header({ showSearch = true }: HeaderProps) {
                 <nav className="flex items-center gap-4 md:gap-6">
                     <Link
                         href="/services"
-                        className="text-sm font-semibold hover:text-[var(--highlight)] transition-colors tracking-tight"
-                        style={{ color: '#FFFFFF' }}
+                        className="text-sm font-semibold text-nav-text hover:text-[var(--highlight)] transition-colors tracking-tight"
                     >
                         Resources
                     </Link>
                     <Link
                         href="/organizations"
-                        className="text-sm font-semibold hover:text-[var(--highlight)] transition-colors tracking-tight"
-                        style={{ color: '#FFFFFF' }}
+                        className="text-sm font-semibold text-nav-text hover:text-[var(--highlight)] transition-colors tracking-tight"
                     >
                         Groups
                     </Link>

--- a/hsdirectory/src/components/ui/NavSubmenu.tsx
+++ b/hsdirectory/src/components/ui/NavSubmenu.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+
+export interface NavSubmenuItem {
+    label: string;
+    href: string;
+}
+
+interface NavSubmenuProps {
+    /** The button label shown in the nav bar. */
+    label: string;
+    /** Links shown in the dropdown. */
+    items: NavSubmenuItem[];
+}
+
+/**
+ * Accessible nav submenu using the disclosure pattern.
+ * Opens on hover or button activation; closes on Escape or focus leaving the container.
+ * Nav link styles live in globals.css (.nav-link).
+ */
+export function NavSubmenu({ label, items }: NavSubmenuProps) {
+    const [open, setOpen] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    // Close on Escape
+    useEffect(() => {
+        function onKeyDown(e: KeyboardEvent) {
+            if (e.key === 'Escape') setOpen(false);
+        }
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, []);
+
+    // Close when focus moves outside the container
+    useEffect(() => {
+        function onFocusOut(e: FocusEvent) {
+            if (containerRef.current && !containerRef.current.contains(e.relatedTarget as Node)) {
+                setOpen(false);
+            }
+        }
+        const el = containerRef.current;
+        el?.addEventListener('focusout', onFocusOut);
+        return () => el?.removeEventListener('focusout', onFocusOut);
+    }, []);
+
+    return (
+        <div
+            ref={containerRef}
+            className="relative"
+            onMouseEnter={() => setOpen(true)}
+            onMouseLeave={() => setOpen(false)}
+        >
+            {/* Toggle button */}
+            <button
+                aria-expanded={open}
+                onClick={() => setOpen(v => !v)}
+                className="nav-link inline-flex items-center gap-1 bg-transparent border-0 cursor-pointer"
+            >
+                {label}
+                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                    <path d="M1.50002 4L6.00002 8L10.5 4" stroke="currentColor" strokeWidth="1.5"/>
+                </svg>
+            </button>
+
+            {/* Submenu */}
+            {open && (
+                <ul className="absolute right-0 top-full mt-2 bg-black text-white rounded-lg py-2 min-w-max z-50 before:absolute before:inset-x-0 before:-top-2 before:h-2">
+                    {items.map(item => (
+                        <li key={item.href}>
+                            <a href={item.href} className="nav-link block px-5 py-2">
+                                {item.label}
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/hsdirectory/src/components/ui/NavSubmenu.tsx
+++ b/hsdirectory/src/components/ui/NavSubmenu.tsx
@@ -17,7 +17,6 @@ interface NavSubmenuProps {
 /**
  * Accessible nav submenu using the disclosure pattern.
  * Opens on hover or button activation; closes on Escape or focus leaving the container.
- * Nav link styles live in globals.css (.nav-link).
  */
 export function NavSubmenu({ label, items }: NavSubmenuProps) {
     const [open, setOpen] = useState(false);

--- a/hsdirectory/src/components/ui/Pagination.tsx
+++ b/hsdirectory/src/components/ui/Pagination.tsx
@@ -64,7 +64,7 @@ export function Pagination({ currentPage, totalPages, baseUrl }: PaginationProps
                 </Link>
             ) : (
                 <span className="flex h-10 items-center justify-center rounded-lg px-3 text-sm font-medium 
-          text-[var(--muted)] opacity-40 cursor-not-allowed">
+          text-[var(--muted)] cursor-not-allowed">
                     Previous
                 </span>
             )}
@@ -101,7 +101,7 @@ export function Pagination({ currentPage, totalPages, baseUrl }: PaginationProps
                 </Link>
             ) : (
                 <span className="flex h-10 items-center justify-center rounded-lg px-3 text-sm font-medium 
-          text-[var(--muted)] opacity-40 cursor-not-allowed">
+          text-[var(--muted)] cursor-not-allowed">
                     Next
                 </span>
             )}

--- a/hsdirectory/src/components/ui/TagLink.tsx
+++ b/hsdirectory/src/components/ui/TagLink.tsx
@@ -28,8 +28,8 @@ export function TagLink({
     const baseClasses = `inline-flex items-center rounded-full font-medium transition-opacity hover:opacity-80 ${sizeClasses}`;
     
     const colorClasses = colorScheme === 'coral'
-        ? "bg-[var(--tag-coral-bg)] text-[var(--tag-coral-text)]"
-        : "bg-[var(--tag-olive-bg)] text-[var(--tag-olive-text)]";
+        ? "bg-[var(--tag-coral-bg)] text-[var(--tag-coral-text)] border border-[var(--tag-coral-text)]"
+        : "bg-[var(--tag-olive-bg)] text-[var(--tag-olive-text)] border border-[var(--tag-olive-text)]";
         
     const combinedClasses = `${baseClasses} ${colorClasses} ${className}`.trim();
 


### PR DESCRIPTION
Fixes #3 and #21 

- Improves color contrast for WCAG AA compliance and aligns UI elements and fonts with [mutualaid.nyc Wordpress site](https://mutualaid.nyc/) styles, including matching button styles to mutualaid.nyc styles.
- Matches header to mutualaid.nyc Wordpress site in a move toward aligning user flow between MANYC products. We still need to align the footers, but can tackle that in a separate issue
- Switches map tiles to use a cleaner and simpler base map to reduce visual clutter
- Change homepage content and layout to differentiate this as the Community Resources Library and not repeat content from the mutualaid.nyc homepage like the CTAs.

## Homepage before
<img width="1127" height="711" alt="image" src="https://github.com/user-attachments/assets/b91dd7cb-0d9e-4f14-a382-5a25e9dddd33" />

## Homepage after
<img width="1489" height="708" alt="image" src="https://github.com/user-attachments/assets/65262b23-2258-4685-949a-fcf2d1aaf66e" />

## Map Before
<img width="658" height="655" alt="image" src="https://github.com/user-attachments/assets/137a034a-7c89-4f66-a24b-812222dbed35" />
  
## Map After
<img width="668" height="595" alt="image" src="https://github.com/user-attachments/assets/2b7b4fb0-13a1-4022-a599-d5a3425f82be" />


